### PR TITLE
MIDI file tempo setting

### DIFF
--- a/midi_tokenizer.py
+++ b/midi_tokenizer.py
@@ -221,6 +221,7 @@ class MidiTokenizer:
         beat_offset_idx=None,
         bars_per_batch=None,
         cutoff_time_idx=None,
+        midi_bpm=120
     ):
         """
         tokens : (batch, sequence)
@@ -251,7 +252,7 @@ class MidiTokenizer:
 
         if notes is None:
             notes = []
-        midi = self.notes_to_midi(notes, beatstep, offset_sec=beatstep[beat_offset_idx])
+        midi = self.notes_to_midi(notes, beatstep, offset_sec=beatstep[beat_offset_idx], midi_bpm=midi_bpm)
         return midi, notes
 
     def relative_tokens_to_notes(self, tokens, start_idx, cutoff_time_idx=None):
@@ -339,8 +340,10 @@ class MidiTokenizer:
             notes = notes[note_order.argsort()]
             return notes
 
-    def notes_to_midi(self, notes, beatstep, offset_sec=None):
-        new_pm = pretty_midi.PrettyMIDI(resolution=384, initial_tempo=120.0)
+    def notes_to_midi(self, notes, beatstep, offset_sec=None, midi_bpm=120.0):
+        if midi_bpm <= 0.0:
+            midi_bpm = 120.0
+        new_pm = pretty_midi.PrettyMIDI(resolution=384, initial_tempo=midi_bpm)
         new_inst = pretty_midi.Instrument(program=0)
         new_notes = []
         if offset_sec is None:

--- a/midi_tokenizer.py
+++ b/midi_tokenizer.py
@@ -221,7 +221,7 @@ class MidiTokenizer:
         beat_offset_idx=None,
         bars_per_batch=None,
         cutoff_time_idx=None,
-        midi_bpm=120
+        midi_bpm=120.0,
     ):
         """
         tokens : (batch, sequence)

--- a/transformer_wrapper.py
+++ b/transformer_wrapper.py
@@ -152,7 +152,7 @@ class TransformerWrapper(pl.LightningModule):
             beatstep=ext_beatstep,
             bars_per_batch=n_bars,
             cutoff_time_idx=(n_bars + 1) * 4,
-            midi_bpm=midi_bpm
+            midi_bpm=midi_bpm,
         )
 
         return relative_tokens, notes, pm
@@ -303,7 +303,7 @@ class TransformerWrapper(pl.LightningModule):
             max_batch_size=max_batch_size,
             n_bars=n_bars,
             composer_value=composer_value,
-            midi_bpm=midi_bpm
+            midi_bpm=midi_bpm,
         )
 
         for n in pm.instruments[0].notes:

--- a/transformer_wrapper.py
+++ b/transformer_wrapper.py
@@ -71,6 +71,7 @@ class TransformerWrapper(pl.LightningModule):
         max_batch_size=64,
         n_bars=None,
         composer_value=None,
+        midi_bpm=120,
     ):
         """
         generate a long audio sequence
@@ -151,6 +152,7 @@ class TransformerWrapper(pl.LightningModule):
             beatstep=ext_beatstep,
             bars_per_batch=n_bars,
             cutoff_time_idx=(n_bars + 1) * 4,
+            midi_bpm=midi_bpm
         )
 
         return relative_tokens, notes, pm
@@ -216,6 +218,7 @@ class TransformerWrapper(pl.LightningModule):
         mix_sample_rate=None,
         audio_y=None,
         audio_sr=None,
+        midi_bpm=120,
     ):
         config = self.config
         device = self.device
@@ -300,6 +303,7 @@ class TransformerWrapper(pl.LightningModule):
             max_batch_size=max_batch_size,
             n_bars=n_bars,
             composer_value=composer_value,
+            midi_bpm=midi_bpm
         )
 
         for n in pm.instruments[0].notes:

--- a/transformer_wrapper.py
+++ b/transformer_wrapper.py
@@ -71,7 +71,7 @@ class TransformerWrapper(pl.LightningModule):
         max_batch_size=64,
         n_bars=None,
         composer_value=None,
-        midi_bpm=120,
+        midi_bpm=120.0,
     ):
         """
         generate a long audio sequence
@@ -218,7 +218,7 @@ class TransformerWrapper(pl.LightningModule):
         mix_sample_rate=None,
         audio_y=None,
         audio_sr=None,
-        midi_bpm=120,
+        midi_bpm=120.0,
     ):
         config = self.config
         device = self.device


### PR DESCRIPTION
For specify the tempo of the output midi file, added `midi_bpm=120.0` option to `TransformerWrapper.generate()` to be carried up to `PrettyMIDI()` of `MidiTokenizer.notes_to_midi()`.

I don't think this will affect the existing scripts, but it's a rough implementation so I'm not sure.
